### PR TITLE
fix: fix hls for play

### DIFF
--- a/write.go
+++ b/write.go
@@ -227,11 +227,9 @@ func (t *TrackReader) frag(hls *HLSWriter, ts time.Duration) (err error) {
 				if err = t.playlist.Init(); err != nil {
 					return
 				}
-				//playlist起点是ring.next，长度是len(ring)-1
-				fmt.Println("现在的playlist是：")
+				//playlist起点是ring.next，长度是len(ring)-1				
 				for p := t.infoRing.Next(); p != t.infoRing; p = p.Next() {
 					t.playlist.WriteInf(p.Value.(PlaylistInf))
-					fmt.Println("##_", p.Value.(PlaylistInf).Title)
 				}
 			} else {
 				if err = t.playlist.WriteInf(t.infoRing.Prev().Value.(PlaylistInf)); err != nil {
@@ -243,7 +241,6 @@ func (t *TrackReader) frag(hls *HLSWriter, ts time.Duration) (err error) {
 		}
 
 		if t.hls_segment_count >= t.hls_segment_window {
-			fmt.Println("[zjx] delete ts=", t.infoRing.Value.(PlaylistInf).FilePath)
 			if mts, loaded := hls.memoryTs.Delete(t.infoRing.Value.(PlaylistInf).FilePath); loaded {
 				mts.Recycle()
 			}

--- a/write.go
+++ b/write.go
@@ -40,6 +40,8 @@ type TrackReader struct {
 	hls_segment_count uint32 // hls segment count
 	playlist          Playlist
 	infoRing          *ring.Ring
+	hls_playlist_count uint32
+	hls_segment_window uint32
 }
 
 func (tr *TrackReader) init(hls *HLSWriter, media *track.Media, pid uint16) {
@@ -49,7 +51,8 @@ func (tr *TrackReader) init(hls *HLSWriter, media *track.Media, pid uint16) {
 	tr.pes = &mpegts.MpegtsPESFrame{
 		Pid: pid,
 	}
-	tr.infoRing = ring.New(hlsConfig.Window)
+	tr.hls_segment_window = uint32(hlsConfig.Window) + 1
+	tr.infoRing = ring.New(int(tr.hls_segment_window))
 	tr.m3u8Name = hls.Stream.Path + "/" + media.Name
 	tr.AVRingReader = hls.CreateTrackReader(media)
 	tr.playlist = Playlist{
@@ -190,15 +193,19 @@ func (t *TrackReader) frag(hls *HLSWriter, ts time.Duration) (err error) {
 	// 当前的时间戳减去上一个ts切片的时间戳
 	if dur := ts - t.write_time; dur >= hlsConfig.Fragment {
 		// fmt.Println("time :", video.Timestamp, tsSegmentTimestamp)
-		tsFilename := t.Track.Name + strconv.FormatInt(time.Now().Unix(), 10) + ".ts"
+		if dur == ts && t.write_time == 0 {//时间戳不对的情况，首个默认为2s
+			dur = time.Duration(2) * time.Second
+		}
+		num := uint32(t.hls_segment_count)
+		tsFilename := t.Track.Name + strconv.FormatInt(time.Now().Unix(), 10) + "_" + strconv.FormatUint(uint64(num), 10) + ".ts"
 		tsFilePath := streamPath + "/" + tsFilename
 
-		hls.memoryTs.Store(tsFilePath, t.ts)
 		// println(hls.currentTs.Length)
 		t.ts = &MemoryTs{
 			BytesPool: t.ts.BytesPool,
 			PMT:       t.ts.PMT,
 		}
+		hls.memoryTs.Store(tsFilePath, t.ts)
 		if t.playlist.Targetduration < int(dur.Seconds()) {
 			t.playlist.Targetduration = int(math.Ceil(dur.Seconds()))
 		}
@@ -213,31 +220,42 @@ func (t *TrackReader) frag(hls *HLSWriter, ts time.Duration) (err error) {
 		}
 		t.Lock()
 		defer t.Unlock()
-		if t.hls_segment_count >= uint32(hlsConfig.Window) {
-			t.M3u8.Reset()
-			if err = t.playlist.Init(); err != nil {
-				return
+
+		if t.hls_segment_count > 0 {
+			if t.hls_playlist_count >= uint32(hlsConfig.Window) {
+				t.M3u8.Reset()
+				if err = t.playlist.Init(); err != nil {
+					return
+				}
+				//playlist起点是ring.next，长度是len(ring)-1
+				fmt.Println("现在的playlist是：")
+				for p := t.infoRing.Next(); p != t.infoRing; p = p.Next() {
+					t.playlist.WriteInf(p.Value.(PlaylistInf))
+					fmt.Println("##_", p.Value.(PlaylistInf).Title)
+				}
+			} else {
+				if err = t.playlist.WriteInf(t.infoRing.Prev().Value.(PlaylistInf)); err != nil {
+					return
+				}
 			}
+			memoryM3u8.LoadOrStore(t.m3u8Name, t)
+			t.hls_playlist_count++
+		}
+
+		if t.hls_segment_count >= t.hls_segment_window {
+			fmt.Println("[zjx] delete ts=", t.infoRing.Value.(PlaylistInf).FilePath)
 			if mts, loaded := hls.memoryTs.Delete(t.infoRing.Value.(PlaylistInf).FilePath); loaded {
 				mts.Recycle()
 			}
 			t.infoRing.Value = inf
 			t.infoRing = t.infoRing.Next()
-			t.infoRing.Do(func(i interface{}) {
-				t.playlist.WriteInf(i.(PlaylistInf))
-			})
 		} else {
 			t.infoRing.Value = inf
 			t.infoRing = t.infoRing.Next()
-			if err = t.playlist.WriteInf(inf); err != nil {
-				return
-			}
 		}
 		t.hls_segment_count++
-		t.write_time = ts
-		if t.playlist.tsCount > 0 {
-			memoryM3u8.LoadOrStore(t.m3u8Name, t)
-		}
+		t.write_time = ts		
+
 	}
 	return
 }


### PR DESCRIPTION
1、在播放hls的时候，在不同推流中会出现第一个ts的duration很大的情况
#EXTM3U
#EXT-X-VERSION:3
#EXT-X-MEDIA-SEOWENCE:0
#EXT-X-TARGETDURATION: 395
#EXTINF:394.760,
h2641696835298 ts
#EXTINF:2.830,
h2641696835298 ts
解决方法：
在frag函数中默认首次为2即可

2、在播放hls的时候，出现第一个ts和第二个ts同名的情况，会导致后续相关数据结构load或store导致对象发生改变，出现无法正常播放的情况。（如第一个ts只有PMT数据600+B的情况）
解决方法：
测试发现是第一个gop和第二个gop容易在1秒内完成，而ts命名是用秒来命名，所以会导致ts同名，在frag函数中对ts命名增加hls_segment_count来区分即可。

3、在播放hls的时候，出现第一个ts实际是无效的情况，因为原文中先进行Store再为t.ts指定下一个对象
hls.memoryTs.Store(tsFilePath, t.ts)
t.ts = &MemoryTs{...}
解决方法：
t.playlist和ts.infoRing里的内容分开管理，infoRing的长度为playlist长度+1
在第一个ts生成后记录到infoRing里；在第二个ts生成后，将前一个ts写入playlist，再讲第二个ts记录到infoRing里；以此类推
且第一次播放测试与中途播放测试均正常
